### PR TITLE
Added a german translation file in 18n folder.

### DIFF
--- a/Community/i18n/de/strings.xml
+++ b/Community/i18n/de/strings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+	<string name="stream">Stream</string>
+	<string name="groups">Gruppen</string>
+	<string name="events">Veranstaltungen</string>
+	<string name="leaders">Spitzenreiter</string>
+	<string name="checkin">Einchecken</string>
+	<string name="settings">Einstellungen</string>
+	<string name="cancel">Abbrechen</string>
+	<string name="done">Fertig</string>
+</resources>


### PR DESCRIPTION
Added a german translation file in 18n.
The word "stream" has no complement in germany. It should be unchanged.
Everybody know´s the word in germany. It´s like "denglish" which mean
"deutsch-english"
